### PR TITLE
Document rich dependency and add stub

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -13,6 +13,12 @@ The MIID codebase includes unit tests in the `tests/` directory:
 - `test_template_validator.py`: Tests for the validator functionality
 - `helpers.py`: Helper functions for testing
 
+> **Note**
+> The tests rely on the [`rich`](https://pypi.org/project/rich/) library for
+> capturing console output. It is included in `requirements.txt`. If you cannot
+> install external packages, a lightweight stub is provided in
+> `tests/helpers.py` that is used automatically when `rich` is missing.
+
 ### Running Tests
 
 To run all tests:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,8 +29,40 @@ from bittensor.mock.wallet_mock import get_mock_hotkey as _get_mock_hotkey
 from bittensor.mock.wallet_mock import get_mock_keypair as _get_mock_keypair
 from bittensor.mock.wallet_mock import get_mock_wallet as _get_mock_wallet
 
-from rich.console import Console
-from rich.text import Text
+try:
+    from rich.console import Console
+    from rich.text import Text
+except ModuleNotFoundError:  # pragma: no cover - stub for environments without rich
+    class Console:
+        """Minimal stub of rich.console.Console used for tests."""
+
+        def __init__(self, *args, **kwargs):
+            self._buffer = []
+
+        def begin_capture(self):
+            self._buffer = []
+
+        def print(self, *args, **kwargs):
+            self._buffer.append(" ".join(str(a) for a in args))
+
+        def end_capture(self):
+            output = "\n".join(self._buffer)
+            self._buffer = []
+            return output
+
+    class Text:
+        """Minimal stub of rich.text.Text used for tests."""
+
+        def __init__(self, text: str = ""):
+            self.plain = text
+
+        @staticmethod
+        def from_markup(text: str) -> "Text":
+            return Text(text)
+
+        @staticmethod
+        def from_ansi(text: str) -> "Text":
+            return Text(text)
 import bittensor as bt
 import torch
 from MIID.protocol import IdentitySynapse


### PR DESCRIPTION
## Summary
- provide lightweight stub of `rich` when not installed
- document need for the `rich` package in test docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bittensor')*

------
https://chatgpt.com/codex/tasks/task_e_688000a9756883258c5d7653532c4c42