### PR TITLE
Add instructions for Chutes API key

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -77,6 +77,19 @@ ollama pull llama3.1:latest
   - Set up monitoring and logging
   - Consider using a more powerful GPU for faster inference
 
+## Chutes API Key
+
+The miner uses the [Chutes](https://chutes.ai) API to generate name variations.
+Create an account on the [Chutes portal](https://portal.chutes.ai) and obtain an
+API key. Export this key before starting the miner:
+
+```bash
+export CHUTES_API_KEY=<your-key>
+```
+
+The miner reads the `CHUTES_API_KEY` environment variable at startup and will
+log a warning if it is not set.
+
 ## Running a Miner
 
 1. Register your miner to the subnet:


### PR DESCRIPTION
## Summary
- document how to obtain a Chutes API key
- describe exporting the API token for the miner

## Testing
- `pip install -e .` *(fails: internet disabled)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bittensor')*

------
https://chatgpt.com/codex/tasks/task_e_688000b8494c8325b06a88f2c0c246a5