### PR TITLE
Add miner prompt/parsing tests

### DIFF
--- a/tests/test_miner_parsing.py
+++ b/tests/test_miner_parsing.py
@@ -1,0 +1,25 @@
+import pytest
+
+from neurons.miner import Miner
+
+
+def create_dummy_miner():
+    config = Miner.config()
+    config.mock = True
+    return Miner(config=config)
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        ("alice:a1,a2;bob:b1,b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
+        ("alice:a1,a2;\nbob:b1,b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
+        ("1) alice - a1, a2; 2) bob - b1, b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
+    ],
+)
+def test_process_batch_response(response, expected):
+    miner = create_dummy_miner()
+    result = miner.process_batch_response(response, list(expected.keys()), 0, "")
+    for name, vars in expected.items():
+        assert result[name][: len(vars)] == vars
+

--- a/tests/test_miner_prompt.py
+++ b/tests/test_miner_prompt.py
@@ -1,0 +1,16 @@
+import pytest
+
+from neurons.miner import Miner
+
+
+def create_dummy_miner():
+    config = Miner.config()
+    config.mock = True
+    return Miner(config=config)
+
+
+def test_build_prompt_contains_name_and_semicolon():
+    miner = create_dummy_miner()
+    prompt = miner.build_prompt(["alice"])
+    assert "alice:" in prompt
+    assert ";" in prompt


### PR DESCRIPTION
## Summary
- add unit tests for miner prompt builder
- add parsing unit tests covering newline, numbers, semicolons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for bittensor)*

------
https://chatgpt.com/codex/tasks/task_e_6880ef05252c8325bfcddede02835ba8