### PR TITLE
Improve regex-based variation parsing

### DIFF
--- a/tests/test_process_batch_response.py
+++ b/tests/test_process_batch_response.py
@@ -1,0 +1,11 @@
+import bittensor as bt
+from neurons.miner import Miner
+
+
+def test_process_batch_response_with_spaces_and_newlines():
+    miner = Miner(config=bt.config())
+    response = "john  :  j1, j2 ;\n jane: j3 ,j4 ; bob :b1,b2"
+    result = miner.process_batch_response(response, ["john", "jane", "bob"], 0, "")
+    assert result["john"][:2] == ["j1", "j2"]
+    assert result["jane"][:2] == ["j3", "j4"]
+    assert result["bob"][:2] == ["b1", "b2"]


### PR DESCRIPTION
## Summary
- parse batch responses with regex for more robust matching
- test parsing with irregular whitespace

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bittensor')*

------
https://chatgpt.com/codex/tasks/task_e_6880ece08748832594f161e6510682e4