### PR TITLE
Improve prompt format and response parsing

### DIFF
--- a/tests/test_miner_parsing.py
+++ b/tests/test_miner_parsing.py
@@ -12,8 +12,8 @@ def create_dummy_miner():
 @pytest.mark.parametrize(
     "response,expected",
     [
-        ("alice:a1,a2;bob:b1,b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
-        ("alice:a1,a2;\nbob:b1,b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
+        ("alice:a1,a2\nbob:b1,b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
+        ("alice:a1,a2; bob:b1,b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
         ("1) alice - a1, a2; 2) bob - b1, b2", {"alice": ["a1", "a2"], "bob": ["b1", "b2"]}),
     ],
 )

--- a/tests/test_miner_prompt.py
+++ b/tests/test_miner_prompt.py
@@ -9,8 +9,8 @@ def create_dummy_miner():
     return Miner(config=config)
 
 
-def test_build_prompt_contains_name_and_semicolon():
+def test_build_prompt_contains_name_and_newline():
     miner = create_dummy_miner()
     prompt = miner.build_prompt(["alice"])
     assert "alice:" in prompt
-    assert ";" in prompt
+    assert "\n" in prompt


### PR DESCRIPTION
## Summary
- enforce newline-based name variation format in miner prompt and system message
- parse LLM output by line and ignore malformed lines
- update miner prompt and parsing tests for new format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bittensor')*

------
https://chatgpt.com/codex/tasks/task_e_6881191119cc8325ac5e50ff6ff9594f